### PR TITLE
Added 'codeblock' button to 'ask' message and updated 'codeblock' output

### DIFF
--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -1,4 +1,4 @@
-import { MessageEmbed } from 'discord.js';
+import { MessageEmbed, ActionRowBuilder, Button } from 'discord.js';
 import universalEmbed from '../index';
 export default {
   ask: {
@@ -6,11 +6,19 @@ export default {
       new MessageEmbed(universalEmbed)
         .setTitle('Dont ask to ask - Just ask!')
         .addFields({
-          // TODO: Turn slash command reference into a button
-          name: 'Describe what your code/hardware does and what you want it to do instead. Sharing is caring! Share your code, use /tag `name: codeblock` to learn how.',
+          name: 'Describe what your code/hardware does and what you want it to do instead. Sharing is caring! Share your code, click the "codeblock" button below to learn how.',
           value:
             'Keep in mind: no one here is paid to help you, so the least you can do is to refine your question in a proper language.',
         }),
+    ],
+    components: [
+        new ActionRowBuilder<ButtonBuilder>()
+        .addComponents(
+            new ButtonBuilder()
+            .setCustomId('codeblock')
+            .setLabel('codeblock')
+            .setStyle(ButtonStyle.Primary);
+        );
     ],
   },
   avrdude: {
@@ -79,15 +87,6 @@ export default {
     ],
   },
   codeblock: {
-    embeds: [
-      new MessageEmbed(universalEmbed)
-        .setTitle('How to Send Code Blocks')
-        .addFields({
-          name: 'Surround the code in three backticks',
-          value:
-            'If using new lines, a file extension can be placed directly after the first 3 backticks to highlight in that language. An example is shown below, highlighting code in arduino. The backtick key is typically found to the left of the 1 key.',
-        })
-        .setImage("https://cdn.blulight.show/xvcZVjDrGN3j/direct")
-    ],
+    content: '```ino\n// Please right-click on this message (long-press on mobile)\n// then select "Copy Text."\n\n// After that, copy your code; then paste it in place of this comment\n```'
   },
 };

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -1,4 +1,4 @@
-import { MessageEmbed, ActionRowBuilder, Button } from 'discord.js';
+import { MessageEmbed, ActionRowBuilder, ButtonBuilder } from 'discord.js';
 import universalEmbed from '../index';
 export default {
   ask: {


### PR DESCRIPTION
Please let me know if the updated button works correctly (don't have sapphire framework installed on my bots' server & don't want to have to restart my bots to update discord.js & install sapphire framework today).

Also, I updated the codeblock: output to the 3rd message from the survey. it requires being sent as a "standard message" to be copyable on all platforms. If that does not work well with the "look and feel" with all other bot messages being in embeds, I guess I'll have to work to find another alternative way to accomplish the goal.