### PR TITLE
bot-command embed now entices users to the bot-command channel. avrdu…

### DIFF
--- a/src/commands/about.ts
+++ b/src/commands/about.ts
@@ -27,7 +27,7 @@ export class AboutCommand extends Command {
           { name: 'Node Version', value: process.version, inline: true },
           {
             name: 'Contributing',
-            value: '[GitHub](https://github.com/BluLightShow/arduino-bot)',
+            value: '[GitHub](https://github.com/arduinodiscord/bot)',
             inline: true
           },
         ]),

--- a/src/commands/tag.ts
+++ b/src/commands/tag.ts
@@ -83,12 +83,12 @@ export class TagCommand extends Command {
     if (user) {
       // Notify the user in the original channel (not ephemeral)
       return interaction.reply({
-        content: `<@${user.id}>`,
+        content: `<@${user.id}> you've been tagged with standard helpful info.`,
         ephemeral: false,
         embeds: [
           new EmbedBuilder(universalEmbed)
-          .setTitle("Tag Sent")
-          .setDescription(`See <#${BOT_COMMANDS_CHANNEL_ID}>`)
+          .setTitle("Your answer is in the Bot-Commands Channel...")
+	  .setDescription(`See <#${BOT_COMMANDS_CHANNEL_ID}> for your info!`) //todo: 'info about <@$tagName}>!' would be better
         ],
       });
     } else {
@@ -98,8 +98,8 @@ export class TagCommand extends Command {
         ephemeral: true,
         embeds: [
           new EmbedBuilder(universalEmbed)
-          .setTitle("Tag Sent")
-          .setDescription(`See <#${BOT_COMMANDS_CHANNEL_ID}>`)
+          .setTitle("Requested info was sent in the Bot-Commands Channel")
+          .setDescription(`See <#${BOT_COMMANDS_CHANNEL_ID}>... only you can see this message...`)
         ],
       });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,4 +26,4 @@ const client = new SapphireClient({
 logger.info('Attempting to connect to discord client...')
 client.login(BOT_TOKEN)
 
-export default (new EmbedBuilder().setFooter({ text: 'Arduino Bot • Submit bugs on GitHub!' }).setColor('#dc5b05').toJSON())
+export default (new EmbedBuilder().setFooter({ text: 'Arduino Bot • GPL-3.0 • /tag' }).setColor('#dc5b05').toJSON())

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -77,6 +77,7 @@ export default {
           {
             name: "6. Is your cable faulty or capable of sending data?",
             value: "Some USB cables aren't capable of transferring data, and some may be faulty, so make sure to try a different one to see if it works! You should try plugging another device into the cable to see if data can pass through it.\n" + "APPLE computers sometimes have issues with there usb adapters. You need to try other adaptors or buy an official one for your MAC."
+			
           },
           {
             name: "7. Is the power LED lit on your board?",
@@ -84,8 +85,8 @@ export default {
 
           },
           {
-            name: "8. Do you have a Nano or other Atmega 328p-based board?",
-            value: "If so, try using the old bootloader. In the Arduino IDE, go to Tools -> Processor and select 328p (old bootloader). *If your board doesn't have an Atmega 328p, you can skip this step.*"
+            name: "8. Do you have a Nano or similar Atmega 328p-based board?",
+            value: "If so, try using the old bootloader. In the Arduino IDE, go to Tools -> Processor and select 328p (old bootloader). This only applies to Nanos and Nano variants. *Boards this applies to will show the Processor option in the Tools menu. Otherwise, you can skip this step.*"
 
           },
           {


### PR DESCRIPTION
bot-command embed now entices users to the bot-command channel. 

avrdude 8. about 328p's old bootloader states its for Nanos only.

Footer now references /tag and the bot license to entice use and contributions.

Updated Github link in /about

As yet, untested locally.